### PR TITLE
Use expected default report_type string

### DIFF
--- a/lib/github_stats/cli.rb
+++ b/lib/github_stats/cli.rb
@@ -11,7 +11,7 @@ module GithubStats
     def initialize(remaining_args, options)
       @search_string = remaining_args.join(' ')
       options[:database_url] ||= "sqlite://#{home_dir}/db.sqlite"
-      options[:report_type] ||= 'issues_closed_by_week'
+      options[:report_type] ||= 'closed_by_week'
       options[:ingest] = true unless options.key?(:ingest)
       @options = options
     end


### PR DESCRIPTION
GithubStats::Reports expects a default key of 'closed_by_week'.  Update the default string here to match.